### PR TITLE
fix a path typo, no other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ artifacts, users can begin interacting with the Rapid7 InsightVM/Nexpose API wit
 ## Auto-generating code
 The code and resulting library of this repository have been auto generated using [Swagger Codegen](https://github.com/swagger-api/swagger-codegen)
 along with the most recent Rapid7 InsightVM/Nexpose Swagger file. After each new console release, the script found
-at `setup_workspac/setup_workspace.sh` is run to check if any changes have been made to the API Swagger file. If changes
+at `setup_workspace/setup_workspace.sh` is run to check if any changes have been made to the API Swagger file. If changes
 exist, the script automates the download of swagger-codegen-cli.jar, updates the version, and executes the jar generate
 process. An example command for running codegen to generate Python source is below:
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

`setup_workspace` path was mispelled. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

help someone if they copy and paste

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

eyeball review

### Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Typo fix

### Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply or add additional checks as reminders. -->
- [x] I have updated the documentation accordingly (if changes are required).
- [x] I have tested the changes locally.


### Miscellaneous Details:
<!--- Provide any additional details you feel are relevant. -->
