### PR TITLE
Add scan-assistant to service allowed_values

### DIFF
--- a/rapid7vmconsole/models/site_shared_credential.py
+++ b/rapid7vmconsole/models/site_shared_credential.py
@@ -177,7 +177,7 @@ class SiteSharedCredential(object):
         :param service: The service of this SiteSharedCredential.  # noqa: E501
         :type: str
         """
-        allowed_values = ["as400", "cifs", "cifshash", "cvs", "db2", "ftp", "http", "ms-sql", "mysql", "notes", "oracle", "pop", "postgresql", "remote-exec", "snmp", "snmpv3", "ssh", "ssh-key", "sybase", "telnet", "kerberos", "hana"]  # noqa: E501
+        allowed_values = ["as400", "cifs", "cifshash", "cvs", "db2", "ftp", "http", "ms-sql", "mysql", "notes", "oracle", "pop", "postgresql", "remote-exec", "snmp", "snmpv3", "ssh", "ssh-key", "sybase", "telnet", "kerberos", "hana", "scan-assistant"]  # noqa: E501
         if service not in allowed_values:
             raise ValueError(
                 "Invalid value for `service` ({0}), must be one of {1}"  # noqa: E501


### PR DESCRIPTION
Add scan-assistant to list of service allowed_values

### Description
Added 'scan-assistant' to the list of allowed_values in the service validation check.

### Motivation and Context
When Scan Assistant is created as a Shared Credential, the allowed_values causes an exception.

### How Has This Been Tested?
Modified locally, works as expected with this change.

### Types of changes
- Bug fix/New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] I have updated the documentation accordingly (if changes are required).
- [x ] I have tested the changes locally.

### Miscellaneous Details:
